### PR TITLE
Revert "using memcpy instead of struct assignment"

### DIFF
--- a/ema.c
+++ b/ema.c
@@ -597,7 +597,7 @@ ema_t* ema_new(size_t addr, size_t size, uint32_t alloc_flags,
     ema_t* node = (ema_t*)emalloc(sizeof(ema_t));
     if (node)
     {
-        ema_clone(node, &tmp);
+        *node = tmp;
         replace_ema(node, &tmp);
         return node;
     }


### PR DESCRIPTION
When working with SGX SGK, there was an issue caused by extended register corruption. struct assignment gave the compiler an oppotunity to use XMM register for optimization therefore triggered the issue. But this was not the root cause and this patch just reverted the change.

Signed-off-by: xxu36 <xiaofeng.xu@intel.com>