### PR TITLE
Handle PF during commit with AEX-Notify enabled

### DIFF
--- a/ema.c
+++ b/ema.c
@@ -233,6 +233,11 @@ bool ema_page_committed(ema_t* ema, size_t addr)
                           (addr - ema->start_addr) >> SGX_PAGE_SHIFT);
 }
 
+bool ema_in_commit(ema_t* ema)
+{
+    return ema->in_commit == 1 ? true : false;
+}
+
 // search for a node whose address range contains 'addr'
 ema_t* search_ema(ema_root_t* root, size_t addr)
 {
@@ -588,6 +593,7 @@ ema_t* ema_new(size_t addr, size_t size, uint32_t alloc_flags,
         .eaccept_map = NULL,
         .handler = handler,
         .priv = private_data,
+        .in_commit = 0,
         .next = NULL,
         .prev = NULL,
     };
@@ -640,11 +646,11 @@ static int eaccept_range_backward(const sec_info_t* si, size_t start,
     return 0;
 }
 
-int do_commit(size_t start, size_t size, uint64_t si_flags, bool grow_up)
+static int do_commit(ema_t *node, size_t start, size_t size, uint64_t si_flags, bool grow_up)
 {
     sec_info_t si SGX_SECINFO_ALIGN = {si_flags | SGX_EMA_STATE_PENDING, 0};
     int ret = -1;
-
+    node->in_commit = 1;
     if (grow_up)
     {
         ret = eaccept_range_backward(&si, start, start + size);
@@ -653,6 +659,7 @@ int do_commit(size_t start, size_t size, uint64_t si_flags, bool grow_up)
     {
         ret = eaccept_range_forward(&si, start, start + size);
     }
+    node->in_commit = 0;
 
     return ret;
 }
@@ -674,7 +681,9 @@ int ema_do_commit(ema_t* node, size_t start, size_t end)
         // only commit for uncommitted page
         if (!bit_array_test(node->eaccept_map, pos))
         {
+            node->in_commit = 1;
             int ret = do_eaccept(&si, addr);
+            node->in_commit = 0;
             if (ret != 0)
             {
                 return ret;
@@ -1133,7 +1142,9 @@ int ema_do_commit_data(ema_t* node, size_t start, size_t end, uint8_t* data,
 
     while (addr < end)
     {
+        node->in_commit = 1;
         int ret = do_eacceptcopy(&si, addr, src);
+        node->in_commit = 0;
         if (ret != 0)
         {
             return EFAULT;
@@ -1259,7 +1270,7 @@ int ema_do_alloc(ema_t* node)
     if (alloc_flags & SGX_EMA_COMMIT_NOW)
     {
         int grow_up = (alloc_flags & SGX_EMA_GROWSDOWN) ? 0 : 1;
-        ret = do_commit(tmp_addr, size, node->si_flags, grow_up);
+        ret = do_commit(node, tmp_addr, size, node->si_flags, grow_up);
         if (ret)
         {
             return ret;

--- a/include/ema.h
+++ b/include/ema.h
@@ -78,6 +78,7 @@ extern "C"
     int ema_clear_eaccept_full(ema_t* node);
     int ema_set_eaccept(ema_t* node, size_t start, size_t end);
     bool ema_page_committed(ema_t* ema, size_t addr);
+    bool ema_in_commit(ema_t* ema);
 
     ema_t* search_ema(ema_root_t* root, size_t addr);
     int search_ema_range(ema_root_t* root, size_t start, size_t end,
@@ -89,7 +90,6 @@ extern "C"
     bool find_free_region_at(ema_root_t* root, size_t addr, size_t size,
                              ema_t** next_ema);
 
-    int do_commit(size_t start, size_t size, uint64_t si_flags, bool grow_up);
     int ema_do_commit(ema_t* node, size_t start, size_t end);
     int ema_do_commit_loop(ema_t* first, ema_t* last, size_t start, size_t end);
 

--- a/include/ema_imp.h
+++ b/include/ema_imp.h
@@ -55,6 +55,9 @@ struct ema_t_
     sgx_enclave_fault_handler_t
         handler;  // custom PF handler  (for EACCEPTCOPY use)
     void* priv;   // private data for handler
+
+    uint8_t in_commit;   // indicates commit/commit_data is in progress on this EMA
+                         // 0 = no, 1 = in progress
     ema_t* next;  // next in doubly linked list
     ema_t* prev;  // prev in doubly linked list
 };

--- a/sgx_mm.c
+++ b/sgx_mm.c
@@ -409,6 +409,13 @@ int sgx_mm_enclave_pfhandler(const sgx_pfinfo* pfinfo)
             ret = SGX_MM_EXCEPTION_CONTINUE_EXECUTION;
         goto unlock;
     }
+    if (ema_in_commit(ema))
+    {
+        // Interrupt happens at EACCEPT/EACCEPTCOPY in commit page process.
+        // We need to skip the EACCEPT in the sig handler.
+        ret = SGX_MM_EXCEPTION_CONTINUE_EXECUTION;
+        goto unlock;
+    }
     if (get_ema_alloc_flags(ema) & SGX_EMA_COMMIT_ON_DEMAND)
     {
         if ((pfinfo->pfec.rw == 0 &&


### PR DESCRIPTION
This PR fixes a calling flow issue in EMM that can occur when SGX-EDMM and AEX-Notify are enabled together.
